### PR TITLE
Ignore *.axd Routes

### DIFF
--- a/NuGet/HotTowel/App_Start/HotTowelRouteConfig.cs.pp
+++ b/NuGet/HotTowel/App_Start/HotTowelRouteConfig.cs.pp
@@ -16,6 +16,9 @@ namespace $rootnamespace$.App_Start {
 
     public static void RegisterHotTowelPreStart() {
 
+      // Ignore requests to .axd HttpHandlers
+      System.Web.Routing.RouteTable.Routes.IgnoreRoute("{resource}.axd/{*pathInfo}");
+
       // Preempt standard default MVC page routing to go to HotTowel Sample
       System.Web.Routing.RouteTable.Routes.MapRoute(
           name: "HotTowelMvc",


### PR DESCRIPTION
This commit is not the most DRY way of fixing the problem, but I noticed that HotTowel simply builds on top of the OOTB templates without changing them, so this is keeping with that strategy.

This commit will allow for *.axd files to be served from HotTowel applications without user changes, which will help to support [Glimpse](http://getGlimpse.com), [ELMAH](http://code.google.com/p/elmah/), [Cassette](http://getcassette.net/) and a host of other open source projects. 
