### PR TITLE
Please remove "-debug" suffix from bundle definition

### DIFF
--- a/NuGet/HotTowel/App_Start/BundleConfig.cs.pp
+++ b/NuGet/HotTowel/App_Start/BundleConfig.cs.pp
@@ -13,7 +13,7 @@ namespace $rootnamespace$
             bundles.Add(
               new ScriptBundle("~/scripts/vendor")
                 .Include("~/scripts/jquery-{version}.js")
-                .Include("~/scripts/knockout-{version}.debug.js")
+                .Include("~/scripts/knockout-{version}.js")
                 .Include("~/scripts/toastr.js")
                 .Include("~/scripts/Q.js")
                 .Include("~/scripts/breeze.debug.js")


### PR DESCRIPTION
Please remove "-debug" suffix from bundle definition as it would not work in release mode (compilation debug="false" in web.config) with it
